### PR TITLE
fix(docker-build): Fix transient dependencies

### DIFF
--- a/packages/docker-build/src/commands/build.ts
+++ b/packages/docker-build/src/commands/build.ts
@@ -132,8 +132,8 @@ export default class DockerBuildCommand extends BaseCommand {
 
             await copyProtocolFiles({
               destination: manifestDir,
-              workspaces: project.workspaces,
               report,
+              project,
               parseDescriptor: (descriptor) => {
                 if (descriptor.range.startsWith('exec:')) {
                   const parsed = parseSpec(descriptor.range);

--- a/packages/docker-build/src/utils/copyProtocolFiles.ts
+++ b/packages/docker-build/src/utils/copyProtocolFiles.ts
@@ -1,9 +1,9 @@
 import {
   Descriptor,
   Locator,
+  Project,
   Report,
   structUtils,
-  Workspace,
 } from '@yarnpkg/core';
 import { PortablePath, ppath, xfs } from '@yarnpkg/fslib';
 
@@ -12,55 +12,53 @@ const BUILTIN_REGEXP = /^builtin<([^>]+)>$/;
 
 export default async function copyProtocolFiles({
   destination,
-  workspaces,
   report,
+  project,
   parseDescriptor,
 }: {
   destination: PortablePath;
-  workspaces: Workspace[];
   report: Report;
+  project: Project;
   parseDescriptor: (
     descriptor: Descriptor,
   ) => { parentLocator: Locator; paths: PortablePath[] } | undefined;
 }): Promise<void> {
   const copiedPaths = new Set<string>();
 
-  for (const ws of workspaces) {
-    for (const descriptor of ws.dependencies.values()) {
-      const patchDescriptor = structUtils.isVirtualDescriptor(descriptor)
-        ? structUtils.devirtualizeDescriptor(descriptor)
-        : descriptor;
+  for (const descriptor of project.storedDescriptors.values()) {
+    const resolvedDescriptor = structUtils.isVirtualDescriptor(descriptor)
+      ? structUtils.devirtualizeDescriptor(descriptor)
+      : descriptor;
 
-      const parsed = parseDescriptor(patchDescriptor);
-      if (!parsed) continue;
+    const parsed = parseDescriptor(resolvedDescriptor);
+    if (!parsed) continue;
 
-      const { parentLocator, paths } = parsed;
+    const { parentLocator, paths } = parsed;
 
-      for (const path of paths) {
-        // Ignore builtin modules
-        if (BUILTIN_REGEXP.test(path)) continue;
+    for (const path of paths) {
+      // Ignore builtin modules
+      if (BUILTIN_REGEXP.test(path)) continue;
 
-        // TODO: Handle absolute path
-        if (ppath.isAbsolute(path)) continue;
+      // TODO: Handle absolute path
+      if (ppath.isAbsolute(path)) continue;
 
-        // Get the workspace by parentLocator
-        const parentWorkspace = ws.project.getWorkspaceByLocator(parentLocator);
+      // Get the workspace by parentLocator
+      const parentWorkspace = project.getWorkspaceByLocator(parentLocator);
 
-        // The path relative to the project CWD
-        const relativePath = ppath.join(parentWorkspace.relativeCwd, path);
+      // The path relative to the project CWD
+      const relativePath = ppath.join(parentWorkspace.relativeCwd, path);
 
-        // Skip if the path has been copied already
-        if (copiedPaths.has(relativePath)) continue;
+      // Skip if the path has been copied already
+      if (copiedPaths.has(relativePath)) continue;
 
-        copiedPaths.add(relativePath);
+      copiedPaths.add(relativePath);
 
-        const src = ppath.join(parentWorkspace.cwd, path);
-        const dest = ppath.join(destination, relativePath);
+      const src = ppath.join(parentWorkspace.cwd, path);
+      const dest = ppath.join(destination, relativePath);
 
-        report.reportInfo(null, relativePath);
-        await xfs.mkdirpPromise(ppath.dirname(dest));
-        await xfs.copyFilePromise(src, dest);
-      }
+      report.reportInfo(null, relativePath);
+      await xfs.mkdirpPromise(ppath.dirname(dest));
+      await xfs.copyFilePromise(src, dest);
     }
   }
 }


### PR DESCRIPTION
Fix protocol files of transient dependencies are not copied.

In the following example, protocol files of `@formatjs/intl` are not copied.

```
web -> intl -> @formatjs/intl
```