### PR TITLE
Add `--exclude-dependents` boolean flag

### DIFF
--- a/packages/changed/src/commands/filter.ts
+++ b/packages/changed/src/commands/filter.ts
@@ -13,6 +13,9 @@ export abstract class FilterCommand extends BaseCommand {
   @Command.Array('--exclude')
   public exclude?: string[];
 
+  @Command.Boolean('--exclude-dependents')
+  public excludeDependents?: boolean;
+
   protected async listWorkspaces(
     project: Project,
   ): Promise<readonly Workspace[]> {
@@ -25,7 +28,12 @@ export abstract class FilterCommand extends BaseCommand {
       },
     );
     const files = stdout.split(/\r?\n/);
-    const workspaces = listChangedWorkspaces(project, files);
+
+    const workspaces = listChangedWorkspaces(
+      project,
+      files,
+      this.excludeDependents ?? false,
+    );
     const include = this.include || [];
     const exclude = this.exclude || [];
 

--- a/packages/changed/src/commands/filter.ts
+++ b/packages/changed/src/commands/filter.ts
@@ -16,6 +16,9 @@ export abstract class FilterCommand extends BaseCommand {
   @Command.Boolean('--exclude-dependents')
   public excludeDependents?: boolean;
 
+  @Command.Boolean('--public-only')
+  public publicOnly?: boolean;
+
   protected async listWorkspaces(
     project: Project,
   ): Promise<readonly Workspace[]> {
@@ -46,6 +49,12 @@ export abstract class FilterCommand extends BaseCommand {
         }
 
         if (exclude.length && exclude.includes(name)) {
+          return false;
+        }
+      }
+
+      if (this.publicOnly) {
+        if (ws.manifest.private === true) {
           return false;
         }
       }

--- a/packages/changed/src/utils/listChangedWorkspaces.ts
+++ b/packages/changed/src/utils/listChangedWorkspaces.ts
@@ -4,6 +4,7 @@ import getWorkspaceDependents from './getWorkspaceDependents';
 export default function listChangedWorkspaces(
   project: Project,
   files: readonly string[],
+  excludeDependents: boolean,
 ): readonly Workspace[] {
   const workspaces = new Set<Workspace>();
 
@@ -13,8 +14,10 @@ export default function listChangedWorkspaces(
     if (changed && !workspaces.has(ws)) {
       workspaces.add(ws);
 
-      for (const dep of getWorkspaceDependents(ws)) {
-        workspaces.add(dep);
+      if (!excludeDependents) {
+        for (const dep of getWorkspaceDependents(ws)) {
+          workspaces.add(dep);
+        }
       }
     }
   }


### PR DESCRIPTION
Hi,

Thanks for creating the `changed` plugin!

We're using this in CI at work and we don't version everything in lock step so I'd like a way to avoid including dependencies in the list of changed workspaces.

The default behavior is unchanged but with this update I can do the following:

```
yarn changed list --git-range origin/master --exclude-dependents
```

Definitely open to naming changes on this. Let me know what you think.

-----

I think the root issue might actually be that in our monorepo all packages rely on the root package so any changes there count as a "dependent" change for *all* packages. Maybe adding a flag to ignore the root package's changes when calculating dependents is the better way to go. I see someone already brought that up in #6 

Interested to hear your thoughts.