### PR TITLE
feat(docker-build): add way to use Docker BuildKit

### DIFF
--- a/packages/docker-build/README.md
+++ b/packages/docker-build/README.md
@@ -72,3 +72,7 @@ Copy additional files to a Docker image. This is useful for secret keys or confi
 #### `--production`
 
 Install production dependencies only.
+
+#### `--buildkit`
+
+Build the Docker image using Docker BuildKit, please check the Docker docs for more info: https://docs.docker.com/engine/reference/commandline/buildx_build/

--- a/packages/docker-build/src/commands/build.ts
+++ b/packages/docker-build/src/commands/build.ts
@@ -207,7 +207,7 @@ export default class DockerBuildCommand extends BaseCommand {
             );
           }
 
-          const buildCommand = this.buildKit ? 'buildx build' : 'build';
+          const buildCommand = this.buildKit ? ['buildx', 'build'] : ['build'];
 
           await execUtils.pipevp(
             'docker',

--- a/packages/docker-build/src/commands/build.ts
+++ b/packages/docker-build/src/commands/build.ts
@@ -39,6 +39,9 @@ export default class DockerBuildCommand extends BaseCommand {
   @Command.Boolean('--production')
   public production?: boolean;
 
+  @Command.Boolean('--buildkit')
+  public buildKit?: boolean;
+
   public static usage = Command.Usage({
     category: 'Docker-related commands',
     description: 'Build a Docker image for a workspace',
@@ -64,6 +67,10 @@ export default class DockerBuildCommand extends BaseCommand {
       [
         'Install production dependencies only',
         'yarn docker build --production @foo/bar',
+      ],
+      [
+        'Build a Docker image using BuildKit',
+        'yarn docker build --buildkit @foo/bar',
       ],
     ],
   });
@@ -200,9 +207,11 @@ export default class DockerBuildCommand extends BaseCommand {
             );
           }
 
+          const buildCommand = this.buildKit ? 'buildx build' : 'build';
+
           await execUtils.pipevp(
             'docker',
-            ['build', ...this.args, '-f', dockerFilePath, '.'],
+            [buildCommand, ...this.args, '-f', dockerFilePath, '.'],
             {
               cwd,
               strict: true,

--- a/packages/docker-build/src/commands/build.ts
+++ b/packages/docker-build/src/commands/build.ts
@@ -211,7 +211,7 @@ export default class DockerBuildCommand extends BaseCommand {
 
           await execUtils.pipevp(
             'docker',
-            [buildCommand, ...this.args, '-f', dockerFilePath, '.'],
+            [...buildCommand, ...this.args, '-f', dockerFilePath, '.'],
             {
               cwd,
               strict: true,


### PR DESCRIPTION
I'd like to build my pacakges for different platforms and in order to do that I have to utilize the Docker BuildKit. 

This PR adds the option to change the `build` command into `buildx build` and therefore utilize the [Docker BuildKit](https://docs.docker.com/engine/reference/commandline/buildx_build/)